### PR TITLE
Fix install errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
     name=virtualenvwrapper
     version={{ virtualenvwrapper_version }}
     state=present
+    extra_args="--ignore-installed six"
   tags:
     - virtualenvwrapper
     - virtualenvwrapper_installation

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Install pip
-  apt: name=python-pip
+  easy_install:
+    name: pip
+    state: latest
 
 - name: install virtualenvwrapper
   pip: >


### PR DESCRIPTION
This fixes install errors by upgrading to the latest pip and ignoring already installed `six` module.